### PR TITLE
Hide forgiven debt transactions from list

### DIFF
--- a/src/main/java/com/shmoney/debt/repository/DebtTransactionSpecifications.java
+++ b/src/main/java/com/shmoney/debt/repository/DebtTransactionSpecifications.java
@@ -2,6 +2,7 @@ package com.shmoney.debt.repository;
 
 import com.shmoney.debt.entity.DebtTransaction;
 import com.shmoney.debt.entity.DebtTransactionDirection;
+import com.shmoney.debt.entity.DebtTransactionKind;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.OffsetDateTime;
@@ -37,4 +38,11 @@ public final class DebtTransactionSpecifications {
         
         return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("occurredAt"), to);
     }
+
+    public static Specification<DebtTransaction> hasKind(DebtTransactionKind kind) {
+        if (kind == null) return null;
+
+        return (root, query, cb) -> cb.equal(root.get("kind"), kind);
+    }
 }
+

--- a/src/main/java/com/shmoney/debt/service/DebtTransactionService.java
+++ b/src/main/java/com/shmoney/debt/service/DebtTransactionService.java
@@ -86,6 +86,7 @@ public class DebtTransactionService {
     public Page<DebtTransaction> getPage(Long userId, DebtTransactionFilter filter, Pageable pageable) {
         Specification<DebtTransaction> specification = Specification
                 .where(DebtTransactionSpecifications.belongsToUser(userId))
+                .and(DebtTransactionSpecifications.hasKind(DebtTransactionKind.CASH_FLOW))
                 .and(DebtTransactionSpecifications.hasCounterparty(filter.counterpartyId()))
                 .and(DebtTransactionSpecifications.hasDirection(filter.direction()))
                 .and(DebtTransactionSpecifications.occurredAfter(filter.from()))

--- a/src/test/java/com/shmoney/debt/service/DebtTransactionServiceListTest.java
+++ b/src/test/java/com/shmoney/debt/service/DebtTransactionServiceListTest.java
@@ -1,0 +1,70 @@
+package com.shmoney.debt.service;
+
+import com.shmoney.debt.dto.DebtTransactionFilter;
+import com.shmoney.debt.entity.DebtTransaction;
+import com.shmoney.debt.entity.DebtTransactionKind;
+import com.shmoney.debt.repository.DebtCounterpartyRepository;
+import com.shmoney.debt.repository.DebtTransactionRepository;
+import com.shmoney.wallet.repository.WalletRepository;
+import com.shmoney.wallet.service.WalletService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DebtTransactionServiceListTest {
+
+    @Mock
+    private DebtTransactionRepository transactionRepository;
+    @Mock
+    private DebtCounterpartyRepository counterpartyRepository;
+    @Mock
+    private WalletService walletService;
+    @Mock
+    private WalletRepository walletRepository;
+    @Mock
+    private com.shmoney.currency.service.ExchangeRateService exchangeRateService;
+
+    private DebtTransactionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DebtTransactionService(
+                transactionRepository,
+                counterpartyRepository,
+                walletService,
+                walletRepository,
+                exchangeRateService
+        );
+    }
+
+    @Test
+    void getPageShouldRequestOnlyCashFlowTransactions() {
+        DebtTransaction transaction = new DebtTransaction();
+        transaction.setKind(DebtTransactionKind.CASH_FLOW);
+
+        when(transactionRepository.findAll(any(Specification.class), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(transaction)));
+
+        var result = service.getPage(
+                1L,
+                new DebtTransactionFilter(null, null, null, null),
+                PageRequest.of(0, 50)
+        );
+
+        assertThat(result.getContent()).hasSize(1);
+        verify(transactionRepository).findAll(any(Specification.class), any(PageRequest.class));
+    }
+}


### PR DESCRIPTION
## Summary
- hide forgiven debt entries from the regular debt transactions list
- keep forgiveness persisted in the domain so balances still recalculate correctly
- add focused test coverage for list filtering

## Verification
- ./mvnw -Dtest=DebtTransactionServiceForgiveTest,DebtTransactionServiceListTest test