### PR TITLE
Exclude forgiven debts from general transaction feed

### DIFF
--- a/src/main/java/com/shmoney/debt/service/DebtTransactionService.java
+++ b/src/main/java/com/shmoney/debt/service/DebtTransactionService.java
@@ -86,7 +86,6 @@ public class DebtTransactionService {
     public Page<DebtTransaction> getPage(Long userId, DebtTransactionFilter filter, Pageable pageable) {
         Specification<DebtTransaction> specification = Specification
                 .where(DebtTransactionSpecifications.belongsToUser(userId))
-                .and(DebtTransactionSpecifications.hasKind(DebtTransactionKind.CASH_FLOW))
                 .and(DebtTransactionSpecifications.hasCounterparty(filter.counterpartyId()))
                 .and(DebtTransactionSpecifications.hasDirection(filter.direction()))
                 .and(DebtTransactionSpecifications.occurredAfter(filter.from()))

--- a/src/main/resources/db/migration/V22__exclude_forgiven_debts_from_transaction_feed.sql
+++ b/src/main/resources/db/migration/V22__exclude_forgiven_debts_from_transaction_feed.sql
@@ -1,0 +1,62 @@
+DROP VIEW IF EXISTS user_transaction_feed;
+
+CREATE OR REPLACE VIEW user_transaction_feed AS
+SELECT
+    'CATEGORY'::text AS entry_source,
+    ct.id AS entry_id,
+    ct.user_id,
+    ct.wallet_id,
+    NULL::BIGINT AS counterparty_wallet_id,
+    ct.category_id,
+    ct.type AS category_transaction_type,
+    NULL::BIGINT AS debt_counterparty_id,
+    NULL::VARCHAR AS debt_direction,
+    ct.amount,
+    curr.code AS currency_code,
+    ct.description,
+    ct.occurred_at,
+    ct.created_at,
+    ARRAY[ct.wallet_id]::BIGINT[] AS wallet_ids
+FROM category_transactions ct
+JOIN currencies curr ON curr.id = ct.currency_id
+UNION ALL
+SELECT
+    'TRANSFER'::text AS entry_source,
+    wt.id AS entry_id,
+    u.id AS user_id,
+    wt.from_wallet_id AS wallet_id,
+    wt.to_wallet_id AS counterparty_wallet_id,
+    NULL::BIGINT AS category_id,
+    'TRANSFER'::text AS category_transaction_type,
+    NULL::BIGINT AS debt_counterparty_id,
+    NULL::VARCHAR AS debt_direction,
+    wt.source_amount AS amount,
+    src.code AS currency_code,
+    wt.description,
+    wt.executed_at AS occurred_at,
+    wt.created_at,
+    ARRAY[wt.from_wallet_id, wt.to_wallet_id]::BIGINT[] AS wallet_ids
+FROM wallet_transactions wt
+JOIN wallets wf ON wf.id = wt.from_wallet_id
+JOIN users u ON u.id = wf.user_id
+JOIN currencies src ON src.id = wt.source_currency_id
+UNION ALL
+SELECT
+    'DEBT'::text AS entry_source,
+    dt.id AS entry_id,
+    dt.user_id,
+    dt.wallet_id,
+    NULL::BIGINT AS counterparty_wallet_id,
+    NULL::BIGINT AS category_id,
+    NULL::VARCHAR AS category_transaction_type,
+    dt.counterparty_id AS debt_counterparty_id,
+    dt.direction AS debt_direction,
+    dt.amount,
+    curr.code AS currency_code,
+    dt.description,
+    dt.occurred_at,
+    dt.created_at,
+    ARRAY[dt.wallet_id]::BIGINT[] AS wallet_ids
+FROM debt_transactions dt
+JOIN currencies curr ON curr.id = dt.currency_id
+WHERE dt.kind = 'CASH_FLOW';


### PR DESCRIPTION
## Summary
- return forgiven entries to the debt-specific transactions API
- exclude forgiven debt rows from the general `/api/transactions` feed view
- keep debt balances and forgiveness history intact in the debt domain

## Verification
- ./mvnw -Dtest=DebtTransactionServiceForgiveTest,DebtTransactionServiceListTest test